### PR TITLE
Added PITInfo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+1.2.0 - 2020-08-28
+==================
+
+* added support for PITinfo hat from Charles Hallard (http://hallard.me/category/tinfo/)
+
+
 1.1.1 - 2020-01-15
 ==================
 

--- a/README.md
+++ b/README.md
@@ -49,3 +49,26 @@ Le parseur supporte aussi l'itération :
 ...     print frame
 ...
 ```
+
+Appel avec changement de port (ici `/dev/ttyUSB0`) pour un module Micro Teleinfo 
+```python
+#!/usr/bin/env python
+from teleinfo import Parser
+from teleinfo.hw_vendors import UTInfo2
+ti = Parser(UTInfo2(port="/dev/ttyUSB0"))
+print ti.get_frame()
+```
+
+Script avec changement de vitesse (ici `9600`) pour un module PITInfo en mode standard sur un Linky
+```python
+#!/usr/bin/env python
+from teleinfo import Parser
+from teleinfo.hw_vendors import PITInfo
+ti = Parser(PITInfo(baudrate=9600))
+print ti.get_frame()
+```
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Le parseur supporte aussi l'itération :
 
 * RpiDom
 * SolarBox_USB
-* MircoTeleinfo USB Dongle from Charles Hallard (https://www.tindie.com/products/hallard/micro-teleinfo-v20/)
+* uTeleinfo USB Dongle from Charles Hallard (https://www.tindie.com/products/hallard/micro-teleinfo-v20/)
 * PITinfo Raspberry PI hat from Charles Hallard (https://www.tindie.com/products/hallard/pitinfo/)
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Le parseur supporte aussi l'itération :
 
 * RpiDom
 * SolarBox_USB
-* UTInfo 2.0 USB Dongle from Charles Hallard (http://hallard.me/utinfo/)
+* MircoTeleinfo USB Dongle from Charles Hallard (https://www.tindie.com/products/hallard/micro-teleinfo-v20/)
+* PITinfo Raspberry PI hat from Charles Hallard (https://www.tindie.com/products/hallard/pitinfo/)
 
 ## Example
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 from setuptools import setup
 from setuptools.command.install import install
 
-VERSION = "1.1.2"
+VERSION = "1.2.0"
 
 def readme():
     """print long description"""

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 from setuptools import setup
 from setuptools.command.install import install
 
-VERSION = "1.1.1"
+VERSION = "1.1.2"
 
 def readme():
     """print long description"""

--- a/teleinfo/hw_vendors.py
+++ b/teleinfo/hw_vendors.py
@@ -59,4 +59,11 @@ class UTInfo2(HW_serial_based):
     def read_char(self):
         return self._serial_port.read(1)
 
+class PITInfo(HW_serial_based):
+    def __init__(self, port="/dev/ttyAMA0", *args, **kwargs):
+        super(PITInfo, self).__init__(port, *args, **kwargs)
+
+    def read_char(self):
+        return self._serial_port.read(1)
+
 

--- a/teleinfo/utils.py
+++ b/teleinfo/utils.py
@@ -16,7 +16,8 @@ def frame_to_json():
     SUPPORTED_DEVICES = {
         "RpiDom": RpiDom,
         "SolarBox_USB": SolarBox_USB,
-        "UTInfo2": UTInfo2
+        "UTInfo2": UTInfo2,
+        "PITInfo": PITInfo
     }
 
     def usage():

--- a/teleinfo/utils.py
+++ b/teleinfo/utils.py
@@ -6,7 +6,7 @@ def frame_to_json():
 
     import sys
     import teleinfo
-    from teleinfo.hw_vendors import RpiDom, SolarBox_USB, UTInfo2
+    from teleinfo.hw_vendors import RpiDom, SolarBox_USB, UTInfo2, PITInfo
     import getopt
     import json
 


### PR DESCRIPTION
I've Added PITinfo but as I'm noob in python and class that's the best I can do

I'd like to add (a fix) for UTInfo2, you hard coded the path with serial number, as UTInfo2 board as unique serial number this will works only with your module, so I think the best is to set port as parameter so we can use `/dev/ttyUSB1` or whatever.

Also I would like to add another parameter to handle Linky Standard Mode (9600bps)

Do you think you can handle these parameters or help me do do that I'm lost with class and way to pass parameters ?

Thanks

