### PR TITLE
TCP Connection support

### DIFF
--- a/teleinfo/base_vendor.py
+++ b/teleinfo/base_vendor.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+from abc import ABCMeta, abstractmethod
+
+class BASE_vendor:
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def read_char(self):
+        pass
+
+    def __iter__(self):
+        while True:
+            yield self.read_char()

--- a/teleinfo/hw_vendors.py
+++ b/teleinfo/hw_vendors.py
@@ -3,19 +3,9 @@
 import serial
 import time
 from abc import ABCMeta, abstractmethod
+from .base_vendor import BASE_vendor
 
-class HW_vendor():
-    __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def read_char(self):
-        pass
-
-    def __iter__(self):
-        while True:
-            yield self.read_char()
-
-class HW_serial_based(HW_vendor):
+class HW_serial_based(BASE_vendor):
     __metaclass__ = ABCMeta
 
     BAUDRATE = 1200

--- a/teleinfo/parser.py
+++ b/teleinfo/parser.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from .hw_vendors import HW_vendor
+from .base_vendor import BASE_vendor
 import itertools
 import logging
 
@@ -12,7 +12,7 @@ class Parser:
     MARKER_END_LINE = '\r\n'
 
     def __init__(self, hw=None):
-        assert hw is not None and isinstance(hw, HW_vendor)
+        assert hw is not None and isinstance(hw, BASE_vendor)
         self._hw = hw
         self._synchro_debut_trame()
 

--- a/teleinfo/sw_vendors.py
+++ b/teleinfo/sw_vendors.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+import socket
+import time
+from abc import ABCMeta, abstractmethod
+from .base_vendor import BASE_vendor
+
+class SW_tcp_based(BASE_vendor):
+	__metaclass__ = ABCMeta
+	ADDRESS = "127.0.0.1"
+	PORT = 6001
+
+	def __init__(self, ip_address, port):
+		self.address = (ip_address, port)
+		self.sock = None
+		self.reconnect_socket()
+
+	def reconnect_socket(self):
+		if self.sock is not None:
+			self.sock.close()
+			self.sock = None
+
+		self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		self.sock.connect(self.address)
+
+	def read_char(self):
+		return self.sock.recv(1).decode("ascii")


### PR DESCRIPTION
I run a serial to Ethernet gateway on my linky, hence this PR.

In the 1st commit I moved and renamed the  `HW_vendor` class to another file with a more generic name (`BASE_vendor`), I've modified all the imports of the original files accordingly.

In the 2nd commit I added a simple skeleton for a TCP based connection that can be used like this:
```python
from teleinfo import sw_vendors
from teleinfo import Parser

ti = Parser(sw_vendors.SW_tcp_based("192.168.1.50", 6001))

for frame in ti:
	print(frame)
```

These modifications allow for a greater flexibility of the library by enabling software input, here I've written a simple TCP adapter but something similar could be done with other protocols